### PR TITLE
Use PATH_INFO key in path param in request_spec

### DIFF
--- a/lib/swagger/rack.rb
+++ b/lib/swagger/rack.rb
@@ -3,7 +3,7 @@ require "swagger/base"
 module Swagger
   module RackHelpers
     def request_spec(env: nil)
-      path = env['REQUEST_PATH']
+      path = env['REQUEST_PATH'] || env['PATH_INFO']
       verb = env['REQUEST_METHOD'].downcase
       matching_paths = (@spec['paths'] || {}).map { |spec_path, spec|
         next unless spec[verb]


### PR DESCRIPTION
### Note: The same PR exists against the original gem source, however, I'm adding a PR in case of it being rejected.
### Background

We noticed that whilst trying to get tests to break when using the SpecEnforcer, env['REQUEST_PATH'] wasn't being set and as such, the swagger schema wasn't validated against.

Whilst env['REQUEST_PATH'] is supported in most http servers, it seems that it isn't set when generating request environment variables with Rack::MockRequest#env_for, which is used in 'rack-test' among other gems.

http://www.rubydoc.info/github/rack/rack/Rack%2FMockRequest.env_for

env['PATH_INFO'] is however, and adding in this in the absence of env['REQUEST_PATH'] allowed us to validate with the SpecEnforcer successfully.
### Changes
- Single line change to use env['PATH_INFO'] in the absence of env['REQUEST_PATH']
