### PR TITLE
Allow strict schema enforcement

### DIFF
--- a/lib/sinatra/swagger/spec_enforcer.rb
+++ b/lib/sinatra/swagger/spec_enforcer.rb
@@ -6,7 +6,7 @@ module Sinatra
       def self.registered(app)
         app.register Swagger::SwaggerLinked
 
-        app.after do  
+        app.after do
           next unless response.content_type =~ %r{^application/(?:.+\+)?json$}
           next unless body = JSON.parse(response.body.first) rescue nil
           next if swagger_spec.nil?

--- a/lib/sinatra/swagger/spec_enforcer.rb
+++ b/lib/sinatra/swagger/spec_enforcer.rb
@@ -6,7 +6,7 @@ module Sinatra
       def self.registered(app)
         app.register Swagger::SwaggerLinked
 
-        app.after do
+        app.after do  
           next unless response.content_type =~ %r{^application/(?:.+\+)?json$}
           next unless body = JSON.parse(response.body.first) rescue nil
           next if swagger_spec.nil?

--- a/lib/sinatra/swagger/swagger_linked.rb
+++ b/lib/sinatra/swagger/swagger_linked.rb
@@ -12,6 +12,14 @@ module Sinatra
       end
 
       module Helpers
+        def request_path
+          env['REQUEST_PATH'] || env['PATH_INFO']
+        end
+
+        def request_verb
+          env['REQUEST_METHOD'].downcase
+        end
+
         def swagger_spec
           raise "No swagger file loaded" unless settings.swagger
           settings.swagger.request_spec(env: env)
@@ -21,7 +29,7 @@ module Sinatra
           schema = swagger_spec[:spec]
           path.split("/").each do |key|
             schema = schema[YAML.load(key)]
-            return if schema.nil?
+            raise "No schema response matching path: #{path} for #{request_verb} #{request_path}" if schema.nil?
           end
           schema['definitions'] = settings.swagger['definitions'] if settings.swagger['definitions']
           schema

--- a/lib/sinatra/swagger/swagger_linked.rb
+++ b/lib/sinatra/swagger/swagger_linked.rb
@@ -29,7 +29,7 @@ module Sinatra
           schema = swagger_spec[:spec]
           path.split("/").each do |key|
             schema = schema[YAML.load(key)]
-            raise "No schema response matching path: #{path} for #{request_verb} #{request_path}" if schema.nil?
+            raise "No response schema matching path: #{path} for #{request_verb} #{request_path}" if schema.nil?
           end
           schema['definitions'] = settings.swagger['definitions'] if settings.swagger['definitions']
           schema

--- a/lib/swagger/rack.rb
+++ b/lib/swagger/rack.rb
@@ -18,7 +18,7 @@ module Swagger
 
       case matching_paths.size
       when 0
-        return nil
+        raise "No matching schema for request: #{verb} #{path}"
       when 1
         return matching_paths.first
       else


### PR DESCRIPTION
### Background

This is the Gem we're using for swagger enforcement when **running tests against our code**, which at present only validates the a response against the **required properties** defined in the schema, like the below example:

Example yaml type:

```
type: object
    required:
      - thing_name
      - state
    properties:
      thing_name:
        type: string
        description: Name of the Thing this device is attached to.
      state:
        type: string
        description: New state of the Thing.
```

The above would ensure that thing_name and state are in the JSON response.

However, the gem has on purposely been built to **not** raise exceptions:
- when an end point hasn't been defined in the schema.
- when the response status hasn't been defined in the schema (unexpected status).

```
In order to not be restrictive, if the output doesn't look like JSON or if there's no schema defined, then no action will be taken and the body will be sent to the client.
```
### Description

This pull request changes the behaviour of the gem from the original fork:
- If an end point isn't defined in the schema, verb or path, it will raise an exception now.
- If a response status isn't defined in the schema, it will raise an exception.

This allows for strict enforcement of the schema when testing.
